### PR TITLE
Add a destructor for struct Circom_Circuit to release dynamically allocated memory and prevent memory leaks.

### DIFF
--- a/src/calcwit.cpp
+++ b/src/calcwit.cpp
@@ -65,6 +65,20 @@ Circom_CalcWit::Circom_CalcWit (Circom_Circuit *aCircuit, uint maxTh) {
 
 Circom_CalcWit::~Circom_CalcWit() {
   // ...
+  if (inputSignalAssigned != nullptr) {
+    delete[] inputSignalAssigned;
+    inputSignalAssigned = nullptr;
+  }
+
+  if (signalValues != nullptr) {
+    delete[] signalValues;
+    signalValues = nullptr;
+  }
+
+  if (componentMemory != nullptr) {
+    delete[] componentMemory;
+    componentMemory = nullptr;
+  }
 }
 
 uint Circom_CalcWit::getInputSignalHashPosition(u64 h) {

--- a/src/calcwit.cpp
+++ b/src/calcwit.cpp
@@ -65,20 +65,13 @@ Circom_CalcWit::Circom_CalcWit (Circom_Circuit *aCircuit, uint maxTh) {
 
 Circom_CalcWit::~Circom_CalcWit() {
   // ...
-  if (inputSignalAssigned != nullptr) {
-    delete[] inputSignalAssigned;
-    inputSignalAssigned = nullptr;
-  }
 
-  if (signalValues != nullptr) {
-    delete[] signalValues;
-    signalValues = nullptr;
-  }
+  delete[] inputSignalAssigned;
 
-  if (componentMemory != nullptr) {
-    delete[] componentMemory;
-    componentMemory = nullptr;
-  }
+  delete[] signalValues;
+
+  delete[] componentMemory;
+
 }
 
 uint Circom_CalcWit::getInputSignalHashPosition(u64 h) {

--- a/src/circom.hpp
+++ b/src/circom.hpp
@@ -68,8 +68,6 @@ struct Circom_Circuit {
   }
 };
 
-};
-
 
 struct Circom_Component {
   u32 templateId;

--- a/src/circom.hpp
+++ b/src/circom.hpp
@@ -25,19 +25,19 @@ struct __attribute__((__packed__)) HashSignalInfo {
 struct IODef { 
     u32 offset;
     u32 len;
-    u32 *lengths;
+    u32 *lengths = nullptr;
 };
 
 struct IODefPair { 
     u32 len;
-    IODef* defs;
+    IODef* defs = nullptr;
 };
 
 struct Circom_Circuit {
   //  const char *P;
-  HashSignalInfo* InputHashMap;
-  u64* witness2SignalList;
-  FrElement* circuitConstants;  
+  HashSignalInfo* InputHashMap = nullptr;
+  u64* witness2SignalList = nullptr;
+  FrElement* circuitConstants = nullptr;  
   std::map<u32,IODefPair> templateInsId2IOSignalInfo;
 
   ~Circom_Circuit() {
@@ -76,12 +76,12 @@ struct Circom_Component {
   std::string templateName;
   std::string componentName;
   u64 idFather; 
-  u32* subcomponents;
-  bool* subcomponentsParallel;
-  bool *outputIsSet;  //one for each output
-  std::mutex *mutexes;  //one for each output
-  std::condition_variable *cvs;
-  std::thread *sbct; //subcomponent threads
+  u32* subcomponents = nullptr;
+  bool* subcomponentsParallel = nullptr;
+  bool *outputIsSet = nullptr;  //one for each output
+  std::mutex *mutexes = nullptr;  //one for each output
+  std::condition_variable *cvs = nullptr;
+  std::thread *sbct = nullptr; //subcomponent threads
 
   Circom_Component()
 	: subcomponents(0), subcomponentsParallel(0), outputIsSet(0), mutexes(0), cvs(0), sbct(0)

--- a/src/circom.hpp
+++ b/src/circom.hpp
@@ -39,6 +39,35 @@ struct Circom_Circuit {
   u64* witness2SignalList;
   FrElement* circuitConstants;  
   std::map<u32,IODefPair> templateInsId2IOSignalInfo;
+
+  ~Circom_Circuit() {
+
+    if (InputHashMap != nullptr) {
+      delete[] InputHashMap;
+      InputHashMap = nullptr;
+    }
+
+    if (witness2SignalList != nullptr) {
+      delete[] witness2SignalList;
+      witness2SignalList = nullptr;
+    }
+
+    if (circuitConstants != nullptr) {
+      delete[] circuitConstants;
+      circuitConstants = nullptr;
+    }
+
+    for (auto &pair : templateInsId2IOSignalInfo) {
+      auto *defs = pair.second.defs;
+      if (defs != nullptr) {
+        delete[] defs->lengths;
+        free(defs);
+      }
+
+    }
+  }
+};
+
 };
 
 

--- a/src/circom.hpp
+++ b/src/circom.hpp
@@ -42,20 +42,11 @@ struct Circom_Circuit {
 
   ~Circom_Circuit() {
 
-    if (InputHashMap != nullptr) {
-      delete[] InputHashMap;
-      InputHashMap = nullptr;
-    }
+    delete[] InputHashMap;
 
-    if (witness2SignalList != nullptr) {
-      delete[] witness2SignalList;
-      witness2SignalList = nullptr;
-    }
+    delete[] witness2SignalList;
 
-    if (circuitConstants != nullptr) {
-      delete[] circuitConstants;
-      circuitConstants = nullptr;
-    }
+    delete[] circuitConstants;
 
     for (auto &pair : templateInsId2IOSignalInfo) {
       auto *defs = pair.second.defs;
@@ -63,8 +54,8 @@ struct Circom_Circuit {
         delete[] defs->lengths;
         free(defs);
       }
-
     }
+
   }
 };
 

--- a/src/witnesscalc.cpp
+++ b/src/witnesscalc.cpp
@@ -78,7 +78,7 @@ Circom_Circuit* loadCircuit(const void *buffer, unsigned long buffer_size) {
           memcpy((void *)defs[j].lengths,(void *)(pu32+2),len*sizeof(u32));
           pu32 += len + 2;
         }
-        p.defs = (IODef*)calloc(10, sizeof(IODef));
+        p.defs = (IODef*)calloc(p.len, sizeof(IODef));
         for (u32 j = 0; j < p.len; j++){
           p.defs[j] = defs[j];
         }


### PR DESCRIPTION
close https://github.com/0xPolygonID/witnesscalc/issues/23